### PR TITLE
fix(rendering): fixed unnecessary re-rendering

### DIFF
--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -323,10 +323,16 @@ export default {
     updateCurrentIndex(index) {
       this.currentIndex = index;
     },
-    onDocumentMouseUp() {
+    onDocumentMouseUp(e) {
       /** Clicks outside of dropdown to exit */
       if (this.currentIndex === null || !this.isOpen) {
         this.loading = this.shouldRenderSuggestions();
+        return;
+      }
+
+      /** Do not re-render list on input click  */
+      const isChild = this.$el.contains(e.target);
+      if (isChild && e.target.tagName === 'INPUT') {
         return;
       }
 


### PR DESCRIPTION
* when input was clicked, list would rerender. Now checking that what you clicked is input and not rerendering.

From #32 

- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
