### PR TITLE
fix(inputProps): make name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ For more advanced usage, check out the examples below, and explore the
 | ~~onBlur~~               | ~~Function~~</span> | Deprecated | ~~HTML onblur event on &lt;input> same as Vue @blur event binding~~. You can now use `@blur` which will map to the underlying `<input />`                                    |
 | ~~onFocus~~              | ~~Function~~        | Deprecated | ~~HTML onfocus event on &lt;input> same as Vue @focus event binding~~ You can now use `@focus` which will map to the underlying `<input />`                                  |
 | [`initialValue`](#)      | String              |            | Set some initial value for the `<input>`.                                                                                                                                    |
-| Any DOM Props            | \*                  |            | You can add any props to `<input>` as the component will `v-bind` inputProps. Similar to rest spread in JSX. See more details here: https://vuejs.org/v2/api/#v-bind         |
+| Any DOM Props            | \*                  |            | You can add any props to `<input>` as the component will `v-bind` inputProps. Similar to rest spread in JSX. See more details here: https://vuejs.org/v2/api/#v-bind. The `name` attribute is set to "`q`" by default.         |
 
 <a name="sectionConfigsProp"></a>
 

--- a/__tests__/__snapshots__/autosuggest.test.js.snap
+++ b/__tests__/__snapshots__/autosuggest.test.js.snap
@@ -5,8 +5,7 @@ exports[`Autosuggest can click outside document to trigger close 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -18,6 +17,7 @@ exports[`Autosuggest can click outside document to trigger close 1`] = `
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value="G"
          class="form-control"
   >
@@ -32,8 +32,7 @@ exports[`Autosuggest can display section header 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -45,6 +44,7 @@ exports[`Autosuggest can display section header 1`] = `
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value="G"
          class="form-control autosuggest__input-open"
   >
@@ -110,8 +110,7 @@ exports[`Autosuggest can mount 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -123,6 +122,7 @@ exports[`Autosuggest can mount 1`] = `
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value
          class="form-control"
   >
@@ -137,8 +137,7 @@ exports[`Autosuggest can render default suggestion value by property name 1`] = 
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -150,6 +149,7 @@ exports[`Autosuggest can render default suggestion value by property name 1`] = 
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          onblur="function blurred() {
                 mockFn();
               }"
@@ -186,8 +186,7 @@ exports[`Autosuggest can render simplest component with single onSelected 1`] = 
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -199,6 +198,7 @@ exports[`Autosuggest can render simplest component with single onSelected 1`] = 
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value="phonics"
          class="form-control autosuggest__input-open cool-class"
   >
@@ -381,8 +381,7 @@ exports[`Autosuggest can render suggestions 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -397,6 +396,7 @@ exports[`Autosuggest can render suggestions 1`] = `
          onclick="function clicked() {
         mockFn();
       }"
+         name="q"
          value="clifford kits"
          class="form-control autosuggest__input-open"
   >
@@ -459,8 +459,7 @@ exports[`Autosuggest can select from suggestions using keystroke 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -472,6 +471,7 @@ exports[`Autosuggest can select from suggestions using keystroke 1`] = `
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value="G"
          class="form-control"
   >
@@ -486,8 +486,7 @@ exports[`Autosuggest can use escape key to exit 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -499,6 +498,7 @@ exports[`Autosuggest can use escape key to exit 1`] = `
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value="G"
          class="form-control"
   >
@@ -513,8 +513,7 @@ exports[`Autosuggest is aria complete 1`] = `
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -526,6 +525,7 @@ exports[`Autosuggest is aria complete 1`] = `
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          value="phonics"
          class="form-control autosuggest__input-open"
   >
@@ -588,8 +588,7 @@ exports[`Autosuggest onBlur and onFocus work as expected, including deprecation 
 <div id="autosuggest"
      data-server-rendered="true"
 >
-  <input name="q"
-         type="text"
+  <input type="text"
          autocomplete="off"
          role="combobox"
          aria-autocomplete="list"
@@ -601,6 +600,7 @@ exports[`Autosuggest onBlur and onFocus work as expected, including deprecation 
          initialvalue
          oninputchange="function onInputChange() {}"
          placeholder="Type 'G'"
+         name="q"
          onblur="function blurred() {
                 mockFn();
               }"

--- a/__tests__/autosuggest.test.js
+++ b/__tests__/autosuggest.test.js
@@ -412,4 +412,16 @@ describe("Autosuggest", () => {
       expect(str).toMatchSnapshot();
     });
   });
+
+  it("changes input attributes", () => {
+    const props = { ...defaultProps };
+    props.inputProps = { ...defaultProps.inputProps, name: "my-input" };
+
+    const wrapper = mount(Autosuggest, {
+      propsData: props
+    });
+
+    const input = wrapper.find("input");
+    expect(input.attributes()["name"]).toBe("my-input");
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-autosuggest",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Vue autosuggest component.",
   "engines": {
     "node": "> 4",

--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -1,7 +1,6 @@
 <template>
     <div :id="component_attr_id_autosuggest">
         <input class="form-control"
-               name="q"
                type="text"
                :autocomplete="inputProps.autocomplete"
                role="combobox"
@@ -134,6 +133,7 @@ export default {
     computedSize: 0,
     internal_inputProps: {}, // Nest default prop values don't work currently in Vue
     defaultInputProps: {
+      name: "q", // TODO: 2.0 Deprecate default name value
       initialValue: "",
       autocomplete: "off"
     },
@@ -227,10 +227,10 @@ export default {
 
       const ignoredKeyCodes = [
         16, // Shift
-        9, // Tab
+        9,  // Tab
         18, // alt/option
         91, // OS Key
-        93 // Right OS Key
+        93  // Right OS Key
       ];
 
       if (ignoredKeyCodes.indexOf(keyCode) > -1) {
@@ -420,6 +420,7 @@ export default {
     /** Take care of nested input props */
     this.internal_inputProps = { ...this.defaultInputProps, ...this.inputProps };
     this.inputProps.autocomplete = this.internal_inputProps.autocomplete;
+    this.inputProps.name = this.internal_inputProps.name; // TODO: 2.0 Deprecate default name value
 
     this.searchInput = this.internal_inputProps.initialValue; // set default query, e.g. loaded server side.
   },


### PR DESCRIPTION
Fixes #37

**What**:
Name is now configurable, where before it was always `"q"`

<!-- Why are these changes necessary? -->
**Why**:
When you create a form, the `name` attribute on your inputs are very important. Need to be configurable.

<!-- How were these changes implemented? -->
**How**:
Add name to inputProps defaults so will default to "q", but can be overridden.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
