### PR TITLE
fix: use data as a regular function

### DIFF
--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -124,29 +124,31 @@ export default {
       default: null
     }
   },
-  data: () => ({
-    component_attr_id_autosuggest: "autosuggest",
-    component_attr_class_autosuggest__results_container: "autosuggest__results-container",
-    component_attr_class_autosuggest__results: "autosuggest__results",
-    searchInput: "",
-    searchInputOriginal: null,
-    currentIndex: null,
-    currentItem: null,
-    loading: false /** Helps with making sure the dropdown doesn't stay open after certain actions */,
-    didSelectFromOptions: false,
-    computedSections: [],
-    computedSize: 0,
-    internal_inputProps: {}, // Nest default prop values don't work currently in Vue
-    defaultInputProps: {
-      name: "q", // TODO: 2.0 Deprecate default name value
-      initialValue: "",
-      autocomplete: "off"
-    },
-    defaultSectionConfig: {
-      name: "default",
-      type: "default-section"
-    }
-  }),
+  data() {
+    return {
+      component_attr_id_autosuggest: "autosuggest",
+      component_attr_class_autosuggest__results_container: "autosuggest__results-container",
+      component_attr_class_autosuggest__results: "autosuggest__results",
+      searchInput: "",
+      searchInputOriginal: null,
+      currentIndex: null,
+      currentItem: null,
+      loading: false /** Helps with making sure the dropdown doesn't stay open after certain actions */,
+      didSelectFromOptions: false,
+      computedSections: [],
+      computedSize: 0,
+      internal_inputProps: {}, // Nest default prop values don't work currently in Vue
+      defaultInputProps: {
+        name: "q", // TODO: 2.0 Deprecate default name value
+        initialValue: "",
+        autocomplete: "off"
+      },
+      defaultSectionConfig: {
+        name: "default",
+        type: "default-section"
+      }
+    };
+  },
   computed: {
     listeners() {
       return {


### PR DESCRIPTION
you don't use any `this`, but if you would have, it would be the parent's `this`, and not the component's. That's why it's best practice to not use arrow functions in Vue like that


<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: change `data: () => ({})` to `data() { return {} }`

<!-- Why are these changes necessary? -->
**Why**: Vue will have the wrong `this` otherwise

<!-- How were these changes implemented? -->
**How**: by typing in the GitHub web editor?

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> (Didn't feel like cloning now, but might do later)

<!-- feel free to add additional comments -->