### PR TITLE
fix(ssr) don't change state in mounted to have ssr consistency

### DIFF
--- a/__tests__/autosuggest.test.js
+++ b/__tests__/autosuggest.test.js
@@ -534,7 +534,6 @@ describe("Autosuggest", () => {
     expect(wrapper.find('#automatischsuchen').is('div')).toBe(true);
     expect(wrapper.find('.containerz').is('div')).toBe(true);
     expect(wrapper.find('.resultz-containerz').is('div')).toBe(true);
-    expect(wrapper.find('.resultz').is('div')).toBe(true);
     expect(wrapper.find(`#${defaultProps.inputProps.id}`).is('input')).toBe(true);
 
     const renderer = createRenderer();

--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -280,11 +280,11 @@ export default {
     this.inputProps.name = this.internal_inputProps.name; // TODO: 2.0 Deprecate default name value
 
     this.searchInput = this.internal_inputProps.initialValue; // set default query, e.g. loaded server side.
+    this.loading = this.shouldRenderSuggestions();
   },
   mounted() {
     document.addEventListener("mouseup", this.onDocumentMouseUp);
     document.addEventListener("mousedown", this.onDocumentMouseDown);
-    this.loading = true;
   },
   beforeDestroy() {
     document.removeEventListener("mouseup", this.onDocumentMouseUp)


### PR DESCRIPTION
**What**:
SSR of vue-autosuggest will have flash of suggestions results when server fetches items. This is because `this.loading = true` was set in `mounted()`. I moved this to the end of `created` hook and instead am calling `shouldRenderSuggestions` method in the case that users would like to render the results from the server.

**Why**:
Because SSR is dope and all components should do it.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->