### PR TITLE
fix(style) removes form-control default class requirement

### DIFF
--- a/__tests__/__snapshots__/autosuggest.test.js.snap
+++ b/__tests__/__snapshots__/autosuggest.test.js.snap
@@ -109,7 +109,7 @@ exports[`Autosuggest can display section header 1`] = `
          placeholder="Type 'G'"
          name="q"
          value="G"
-         class="form-control autosuggest__input-open"
+         class="autosuggest__input-open form-control"
   >
   <div class="autosuggest__results-container">
     <div aria-labelledby="autosuggest"
@@ -220,7 +220,7 @@ exports[`Autosuggest can render default suggestion value by property name 1`] = 
                 mockFn();
               }"
          value="Frodo"
-         class="form-control cool-class"
+         class="cool-class"
   >
   <div class="autosuggest__results-container">
   </div>
@@ -247,7 +247,7 @@ exports[`Autosuggest can render simplest component with single onSelected 1`] = 
          placeholder="Type 'G'"
          name="q"
          value="phonics"
-         class="form-control autosuggest__input-open cool-class"
+         class="autosuggest__input-open cool-class"
   >
   <div class="autosuggest__results-container">
     <div aria-labelledby="autosuggest"
@@ -446,7 +446,7 @@ exports[`Autosuggest can render slots 1`] = `
                 mockFn();
               }"
          value="G"
-         class="form-control autosuggest__input-open"
+         class="autosuggest__input-open form-control"
   >
   <div class="autosuggest__results-container">
     <div aria-labelledby="autosuggest"
@@ -544,7 +544,7 @@ exports[`Autosuggest can render suggestions 1`] = `
       }"
          name="q"
          value="clifford kits"
-         class="form-control autosuggest__input-open"
+         class="autosuggest__input-open form-control"
   >
   <div class="autosuggest__results-container">
     <div aria-labelledby="autosuggest"
@@ -673,7 +673,7 @@ exports[`Autosuggest is aria complete 1`] = `
          placeholder="Type 'G'"
          name="q"
          value="phonics"
-         class="form-control autosuggest__input-open"
+         class="autosuggest__input-open form-control"
   >
   <div class="autosuggest__results-container">
     <div aria-labelledby="autosuggest"

--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -2,7 +2,6 @@
   <div :id="componentAttrIdAutosuggest">
     <input 
       v-model="searchInput"
-      class="form-control"
       type="text"
       :autocomplete="inputProps.autocomplete"
       role="combobox"
@@ -164,7 +163,8 @@ export default {
       defaultInputProps: {
         name: "q", // TODO: 2.0 Deprecate default name value
         initialValue: "",
-        autocomplete: "off"
+        autocomplete: "off",
+        class: 'form-control', // TODO: 2.0 remove
       },
       defaultSectionConfig: {
         name: "default",
@@ -278,6 +278,7 @@ export default {
     this.internal_inputProps = { ...this.defaultInputProps, ...this.inputProps };
     this.inputProps.autocomplete = this.internal_inputProps.autocomplete;
     this.inputProps.name = this.internal_inputProps.name; // TODO: 2.0 Deprecate default name value
+    this.inputProps.class = this.internal_inputProps.class; // TODO: 2.0 Deprecate default name value
 
     this.searchInput = this.internal_inputProps.initialValue; // set default query, e.g. loaded server side.
     this.loading = this.shouldRenderSuggestions();


### PR DESCRIPTION
* form-control shouldn't be required as an input class, but defaulting
to form-control for backwards compatibility

@felixledem initially proposed this patch in #84 but needs backwards compatibility. Thanks for the suggestion!