### PR TITLE
Add props for list & list item className

### DIFF
--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -123,7 +123,9 @@ export default {
       default: () => {
         return {
           default: {
-            onSelected: null
+            onSelected: null,
+            listClassName: "",
+            listItemClassName: ""
           }
         };
       }
@@ -246,12 +248,15 @@ export default {
 
           const name = section.name ? section.name : this.defaultSectionConfig.name;
 
-          let { type, limit, label } = this.sectionConfigs[name];
+          let { type, limit, label, listClassName, listItemClassName } = this.sectionConfigs[name];
 
           limit = limit || this.limit
 
           /** Set defaults for section configs. */
           type = type ? type : this.defaultSectionConfig.type;
+
+          listClassName = listClassName || this.sectionConfigs['default']['listClassName'];
+          listItemClassName = listItemClassName || this.sectionConfigs['default']['listItemClassName'];
 
           limit = limit ? limit : Infinity;
           limit = section.data.length < limit ? section.data.length : limit;
@@ -265,7 +270,9 @@ export default {
             limit,
             data: section.data,
             start_index: this.computedSize,
-            end_index: this.computedSize + limit - 1
+            end_index: this.computedSize + limit - 1,
+            listClassName,
+            listItemClassName
           };
           this.computedSections.push(computedSection);
           this.computedSize += limit;

--- a/src/parts/DefaultSection.js
+++ b/src/parts/DefaultSection.js
@@ -47,7 +47,8 @@ const DefaultSection = {
     return h(
       "ul",
       {
-        attrs: { role: "listbox", "aria-labelledby": "autosuggest" }
+        attrs: { role: "listbox", "aria-labelledby": "autosuggest" },
+        class: { [this.section.listClassName]: this.section.listClassName }
       },
       [
         sectionTitle,
@@ -66,7 +67,8 @@ const DefaultSection = {
               class: {
                 "autosuggest__results_item-highlighted":
                   this.getItemIndex(key) == this.currentIndex,
-                autosuggest__results_item: true
+                autosuggest__results_item: true,
+                [this.section.listItemClassName]: this.section.listItemClassName
               },
               on: {
                 mouseenter: this.onMouseEnter,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Class name props for list & list item

<!-- Why are these changes necessary? -->
**Why**: I used bootstrap with autosuggest and I was unable to set classes for the suggestions `ul` and `li` elements. I can now add the bootstrap class names to those elements.

<!-- How were these changes implemented? -->
**How**: Added listClassName and listItemClassName to section configs

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
