### PR TITLE
feat(class) add ul and li class props

### DIFF
--- a/__tests__/__snapshots__/autosuggest.test.js.snap
+++ b/__tests__/__snapshots__/autosuggest.test.js.snap
@@ -107,6 +107,70 @@ exports[`Autosuggest can display section header 1`] = `
 </div>
 `;
 
+exports[`Autosuggest can display ul and li classNames 1`] = `
+<div id="autosuggest"><input type="text" autocomplete="off" role="combobox" aria-autocomplete="list" aria-owns="autosuggest__results" aria-activedescendant="" aria-haspopup="true" aria-expanded="true" id="autosuggest__input" placeholder="Type 'G'" value="G" class="autosuggest__input--open">
+  <div class="autosuggest__results-container">
+    <div aria-labelledby="autosuggest" class="autosuggest__results">
+      <ul role="listbox" aria-labelledby="autosuggest" class="hello-ul">
+        <li role="option" data-suggestion-index="0" data-section-name="default" id="autosuggest__results-item--0" class="autosuggest__results-item hello-li">
+          clifford kits
+        </li>
+        <li role="option" data-suggestion-index="1" data-section-name="default" id="autosuggest__results-item--1" class="autosuggest__results-item hello-li">
+          friendly chemistry
+        </li>
+        <li role="option" data-suggestion-index="2" data-section-name="default" id="autosuggest__results-item--2" class="autosuggest__results-item hello-li">
+          phonics
+        </li>
+        <li role="option" data-suggestion-index="3" data-section-name="default" id="autosuggest__results-item--3" class="autosuggest__results-item hello-li">
+          life of fred
+        </li>
+        <li role="option" data-suggestion-index="4" data-section-name="default" id="autosuggest__results-item--4" class="autosuggest__results-item hello-li">
+          life of fred math
+        </li>
+      </ul>
+      <ul role="listbox" aria-labelledby="autosuggest">
+        <li role="option" data-suggestion-index="5" data-section-name="dogs" id="autosuggest__results-item--5" class="autosuggest__results-item">
+          spike
+        </li>
+        <li role="option" data-suggestion-index="6" data-section-name="dogs" id="autosuggest__results-item--6" class="autosuggest__results-item">
+          bud
+        </li>
+        <li role="option" data-suggestion-index="7" data-section-name="dogs" id="autosuggest__results-item--7" class="autosuggest__results-item">
+          rover
+        </li>
+      </ul>
+      <ul role="listbox" aria-labelledby="autosuggest">
+        <li role="option" data-suggestion-index="8" data-section-name="cats" id="autosuggest__results-item--8" class="autosuggest__results-item">
+          sassy
+        </li>
+        <li role="option" data-suggestion-index="9" data-section-name="cats" id="autosuggest__results-item--9" class="autosuggest__results-item">
+          tuesday
+        </li>
+        <li role="option" data-suggestion-index="10" data-section-name="cats" id="autosuggest__results-item--10" class="autosuggest__results-item">
+          church
+        </li>
+      </ul>
+      <ul role="listbox" aria-labelledby="autosuggest">
+        <li role="option" data-suggestion-index="11" data-section-name="zeu" id="autosuggest__results-item--11" class="autosuggest__results-item">
+          elephant
+        </li>
+        <li role="option" data-suggestion-index="12" data-section-name="zeu" id="autosuggest__results-item--12" class="autosuggest__results-item">
+          lion
+        </li>
+      </ul>
+      <ul role="listbox" aria-labelledby="autosuggest">
+        <li role="option" data-suggestion-index="13" data-section-name="Uhh" id="autosuggest__results-item--13" class="autosuggest__results-item">
+          something
+        </li>
+        <li role="option" data-suggestion-index="14" data-section-name="Uhh" id="autosuggest__results-item--14" class="autosuggest__results-item">
+          something2
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Autosuggest can handle null data 1`] = `
 <div id="autosuggest"><input type="text" autocomplete="off" role="combobox" aria-autocomplete="list" aria-owns="autosuggest__results" aria-activedescendant="" aria-haspopup="false" aria-expanded="false" id="autosuggest__input" placeholder="Type 'G'">
   <div class="autosuggest__results-container">

--- a/__tests__/autosuggest.test.js
+++ b/__tests__/autosuggest.test.js
@@ -754,4 +754,36 @@ describe("Autosuggest", () => {
       expect(str).toMatchSnapshot();
     });
   });
+  
+  it("can display ul and li classNames", async () => {
+    const props = { ...defaultProps };
+    props.sectionConfigs.default.liClass = { 'hello-li': true }
+    props.sectionConfigs.default.ulClass = { 'hello-ul': true }
+
+    const wrapper = mount(Autosuggest, {
+      propsData: props,
+      listeners: defaultListeners,
+      attachToDocument: true
+    });
+
+    const input = wrapper.find("input");
+    input.setValue("G");
+
+    input.trigger("click");
+    input.setValue("G");
+    
+    const ul = wrapper.find("ul")
+    const li = ul.find("li:nth-child(1)")
+
+    expect(ul.classes()).toContain('hello-ul');
+    expect(li.classes()).toContain('hello-li');
+    
+    const renderer = createRenderer();
+    renderer.renderToString(wrapper.vm, (err, str) => {
+      if (err) {
+        return false;
+      }
+      expect(str).toMatchSnapshot();
+    });
+  });
 });

--- a/docs/App.vue
+++ b/docs/App.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="demo">
-    <button @click="toggleDark">go {{ colorMode === 'light' ? 'dark' : 'light' }}</button>
+  <div class="demo" v-if="theme">
+    <button @click="toggleTheme(oppositeTheme)">{{ oppositeTheme === 'light' ? '🌞 Go Light' : 'Go Dark 🌛' }}</button>
     <h1>🔍 Vue-autosuggest</h1>
     <div>
       <vue-autosuggest
@@ -65,13 +65,6 @@ function updateCSSVariables(theme) {
   }
 }
 
-const darkTheme = {
-  bg: '#21222C',
-  header: '#8F73BD',
-  item_color_highlighted: '#80D4E7',
-  item_bg_highlighted: '#363948'
-}
-
 const races = [...new Set(characters.map(c => { return c.Race }))]
 
 export default {
@@ -79,13 +72,16 @@ export default {
     VueAutosuggest
   },
   mounted(){
-    updateCSSVariables(darkTheme)
+    const storageTheme = localStorage.getItem('autosuggest-theme')
+    const theme = storageTheme || (window.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'light')
+    console.log({theme})
+    this.toggleTheme(theme)
   },
   data() {
     return {
       selected: "",
       searchText: "",
-      colorMode: 'dark',
+      theme: null,
       options: races.map(r => ({
         	label: r,
           name: r,
@@ -94,9 +90,11 @@ export default {
       ),
       sectionConfigs: {
         default: {
-          limit: 4
+          limit: 4,
+          ulClass: {'data-darren': true },
+          liClass: {'elf-row': true }
         },
-        hobbits: {
+        Elf: {
           limit: 6
         }
       },
@@ -104,10 +102,29 @@ export default {
         id: "autosuggest__input",
         placeholder: "Search"
       },
+      themes: {
+        dark: {
+          bg: '#21222C',
+          color: 'white',
+          header: '#8F73BD',
+          item_color_highlighted: '#80D4E7',
+          item_bg_highlighted: '#363948',
+        },
+        light: {
+          bg: 'white',
+          header: '#8F73BD',
+          color: 'black',
+          item_color_highlighted: 'black',
+          item_bg_highlighted: '#e0e0e0',
+        }
+      },
       events: []
     };
   },
   computed: {
+    oppositeTheme() {
+      return (this.theme === 'light') ? 'dark' : 'light'
+    },
     filteredOptions() {
       const filtered = []
       if(!this.searchText){
@@ -116,10 +133,14 @@ export default {
       races.forEach(r => {
         const people = this.options.filter(o => o.name === r)[0].data.filter(p => {
           return p.Name.toLowerCase().indexOf(this.searchText.toLowerCase()) > -1;
+        }).map(p => {
+          p.liClass = p.Name === 'Gandalf' ? {'gandalf': true} : null
+          return p
         });
 
         people.length > 0 &&
           filtered.push({
+            name: Object.keys(this.sectionConfigs).indexOf(r) > -1 ? r : 'default',
             label: r,
             data: people
           });
@@ -129,25 +150,11 @@ export default {
     }
   },
   methods: {
-    toggleDark(){
-      this.colorMode = ((this.colorMode === 'dark') ? 'light' : 'dark')
-      if(this.colorMode === 'dark'){
-        updateCSSVariables({
-          bg: '#21222C',
-          color: 'white',
-          header: '#8F73BD',
-          item_color_highlighted: '#80D4E7',
-          item_bg_highlighted: '#363948',
-        })
-      }else{
-        updateCSSVariables({
-          bg: 'white',
-          header: 'black',
-          color: '#21222C',
-          item_color_highlighted: 'black',
-          item_bg_highlighted: '#e0e0e0',
-        })
-      }
+    toggleTheme(theme){
+      this.theme = theme
+      localStorage.setItem('autosuggest-theme', theme)
+      console.log('setting', theme)
+      updateCSSVariables(this.themes[this.theme])
     },
 
     getSuggestionValue(item) {
@@ -179,11 +186,11 @@ button {
   color: var(--theme-color);
   text-transform: uppercase;
   font-weight: 700;
-  font-size: .66rem;
+  font-size: 0.66rem;
   white-space: nowrap;
   border: 3px solid var(--theme-color);
   border-radius: 2rem;
-  padding: .2rem .85rem .25rem .85rem;
+  padding: 0.2rem 0.85rem 0.25rem 0.85rem;
   cursor: pointer;
 }
 
@@ -192,7 +199,7 @@ h1 {
 }
 
 * {
-  transition: height 0.200s linear;
+  transition: height 0.2s linear;
   transition: border-color linear 0.1s;
 }
 
@@ -213,7 +220,8 @@ h1 {
   -moz-box-sizing: border-box;
 }
 
-#autosuggest__input.autosuggest__input--open, #autosuggest__input:hover {
+#autosuggest__input.autosuggest__input--open,
+#autosuggest__input:hover {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   border: 1px solid lightgray;
@@ -223,7 +231,6 @@ h1 {
   position: relative;
   width: 100%;
   background-color: var(--theme-bg);
-  
 }
 
 .autosuggest__results {
@@ -298,5 +305,13 @@ h1 {
 }
 .evt-val {
   color: var(--theme-color);
+}
+
+.elf-row {
+  font-style: italic;
+}
+
+.gandalf {
+  color: var(--theme-header);
 }
 </style>

--- a/src/parts/DefaultSection.js
+++ b/src/parts/DefaultSection.js
@@ -54,12 +54,13 @@ const DefaultSection = {
     return h(
       "ul",
       {
-        attrs: { role: "listbox", "aria-labelledby": "autosuggest" }
+        attrs: { role: "listbox", "aria-labelledby": "autosuggest", ...this.section.ulAttributes },
+        class: this.section.ulClass
       },
       [
         before[0] && before[0] || this.section.label && <li class={beforeClassName}>{this.section.label}</li> || '',
         this.list.map((val, key) => {
-          const item = this.normalizeItemFunction(this.section.name, this.section.type, this.section.label, val)
+          const item = this.normalizeItemFunction(this.section.name, this.section.type, this.section.label, this.section.liClass, val)
           const itemIndex = this.getItemIndex(key)
           const isHighlighted = this._currentIndex === itemIndex || parseInt(this.currentIndex) === itemIndex
 
@@ -69,13 +70,15 @@ const DefaultSection = {
               attrs: {
                 role: "option",
                 "data-suggestion-index": itemIndex,
-                "data-section-name": this.section.name,
-                id: "autosuggest__results-item--" + itemIndex
+                "data-section-name": item.name,
+                id: "autosuggest__results-item--" + itemIndex,
+                ...item.liAttributes
               },
               key: itemIndex,
               class: {
                 "autosuggest__results-item--highlighted": isHighlighted,
-                'autosuggest__results-item': true
+                'autosuggest__results-item': true,
+                ...item.liClass
               },
               on: {
                 mouseenter: this.onMouseEnter,


### PR DESCRIPTION
Adds ability to specify `liClass` and `ulClass` in sections:

e.g.

```js
sectionConfigs: {
  default: {
    limit: 4,
    ulClass: {'a-class-name-here': true },
    // applies to all `<li>` in default sections
    liClass: {'default-row': true }
  },
  Elf: {
    limit: 6,
    liClass: {'elf-row': true }
  }
},
```

Or if your item has a liClass on it, it will be used:
```vue
:suggestions="options"
```

```js
options = [{id: 1, name: 'Gandalf', liClass: 'Gandalf'}]
```

Fixes #90 


