### PR TITLE
feat(js): add highlight props

### DIFF
--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -143,11 +143,11 @@ export default {
     },
     highlightFirstSuggestion: {
       type: Boolean,
-      default: true
+      default: false
     },
     persistHighlighted: {
       type: Boolean,
-      default: true
+      default: false
     },
     suggestions: {
       type: Array,

--- a/src/Autosuggest.vue
+++ b/src/Autosuggest.vue
@@ -141,6 +141,14 @@ export default {
       required: false,
       default: Infinity
     },
+    highlightFirstSuggestion: {
+      type: Boolean,
+      default: true
+    },
+    persistHighlighted: {
+      type: Boolean,
+      default: true
+    },
     suggestions: {
       type: Array,
       required: true
@@ -370,6 +378,13 @@ export default {
         }
       },
       immediate: true
+    },
+    suggestions: {
+      handler(newValue){
+        if (this.highlightFirstSuggestion && newValue.length > 0) {
+          this.setCurrentIndex(1, this.totalResults);
+        }
+      }
     }
   },
   created() {
@@ -628,7 +643,7 @@ export default {
       /* Clicks outside of dropdown */
       if (!isChild) {
         this.loading = true;
-        this.currentIndex = null;
+        (!this.persistHighlighted) && (this.currentIndex = null);
         return;
       }
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Addition of highlight props; `highlightFirstSuggestion` it's verbose; `persistHighlighted` is to not unhighlight when clicked outside.

<!-- Why are these changes necessary? -->
**Why**: Simplify and speed up project research.

<!-- How were these changes implemented? -->
**How**: Just like the other props and with an addition of a watch.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
I tried to make simple, non-immediate changes by setting the props default to false.